### PR TITLE
Export Account via csv

### DIFF
--- a/Gw2Launcher/Program.cs
+++ b/Gw2Launcher/Program.cs
@@ -815,6 +815,49 @@ namespace Gw2Launcher
 
             #endregion
 
+            #region -exportAccounts [path]
+
+            if (args.Length > 0 && args[0] == "-exportcsv")
+            {
+                Settings.Load(); // Maybe I shouldn't do this here?!
+                var gw1Accounts = new List<Settings.IGw1Account>();
+                var gw2Accounts = new List<Settings.IGw2Account>();
+                foreach(var uid in Settings.Accounts.GetKeys())
+                {
+                    switch (Settings.Accounts[uid].Value.Type)
+                    {
+                        case Settings.AccountType.GuildWars1:
+                            gw1Accounts.Add((Settings.IGw1Account)Settings.Accounts[uid].Value);
+                            break;
+                        case Settings.AccountType.GuildWars2:
+                            gw2Accounts.Add((Settings.IGw2Account)Settings.Accounts[uid].Value);
+                            break;
+                    }
+                }
+
+                // Create Gw1Accounts.csv
+                var sb = new System.Text.StringBuilder();
+                sb.AppendLine("sep=,");
+                sb.AppendLine("UID,Name,Email");
+                foreach (var account in gw1Accounts) 
+                {
+                    sb.AppendFormat("{0},{1},{2}", account.UID, account.Name, account.Email).AppendLine();
+                }
+                System.IO.File.WriteAllText(Path.Combine(Gw2Launcher.DataPath.AppData, "Gw1Accounts.csv"), sb.ToString());
+
+                // Create Gw2Accounts.csv
+                sb = new System.Text.StringBuilder();
+                sb.AppendLine("sep=,");
+                sb.AppendLine("UID,Name,Email,API Key");
+                foreach (var account in gw2Accounts)
+                {
+                    sb.AppendFormat("{0},{1},{2},{3}", account.UID, account.Name, account.Email, account.ApiKey).AppendLine();
+                }
+                System.IO.File.WriteAllText(Path.Combine(Gw2Launcher.DataPath.AppData, "Gw2Accounts.csv"), sb.ToString());
+            }
+
+            #endregion
+
             #region QuickLaunch
 
             if (args.Length > 0 && args[0] == "-quicklaunch")

--- a/Gw2Launcher/Program.cs
+++ b/Gw2Launcher/Program.cs
@@ -815,7 +815,7 @@ namespace Gw2Launcher
 
             #endregion
 
-            #region -exportAccounts [path]
+            #region -exportcsv
 
             if (args.Length > 0 && args[0] == "-exportcsv")
             {


### PR DESCRIPTION
Hi,

 I couldn't find a way to easily export the account information into a non-binary format, so I added a command line flag to create 2 csv files with all gw1 and gw2 accounts respectively. I needed that because I always created my accounts on-the-fly and added it to the launcher right away , resulting in me having lost track of all my mail addresses connected to accounts...

I don't really know C#, so this patch might need some work, but I wanted to share it anyways. 

Thanks for your good work! 